### PR TITLE
Check empty hostname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: go
 sudo: false
 install: true
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.11.x
+  - 1.10.x
   - tip
-env:
-  global:
-    - GO15VENDOREXPERIMENT=1
 script: go test ./...
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ install: true
 go:
   - 1.11.x
   - 1.10.x
-  - tip
+  - master
 script: go test ./...
 matrix:
   allow_failures:
-    - go: tip
+    - go: master

--- a/app.go
+++ b/app.go
@@ -40,6 +40,9 @@ func startApp(app App) {
 }
 
 func getApp(hostname string) (*App, error) {
+	if len(hostname) == 0 {
+		return nil, fmt.Errorf("Empty hostname")
+	}
 	apps, err := listApps()
 	if err != nil {
 		return nil, err

--- a/app_test.go
+++ b/app_test.go
@@ -99,3 +99,16 @@ func (s *Suite) TestGetAppNotFound(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "App myapp.mytsuru.com not found")
 	c.Assert(app, check.IsNil)
 }
+
+func (s *Suite) TestGetAppEmptyIp(c *check.C) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Fail()
+	}))
+	defer ts.Close()
+	os.Setenv("TSURU_HOST", ts.URL)
+	os.Setenv("TSURU_TOKEN", "123")
+
+	app, err := getApp("")
+	c.Assert(err, check.ErrorMatches, "Empty hostname")
+	c.Assert(app, check.IsNil)
+}


### PR DESCRIPTION
If `Host` is empty, caffeine would match the first app with an empty `Ip` field (any app without router). This PR fixes it.